### PR TITLE
removed the nodal_smoothing parameter

### DIFF
--- a/kratos_element_test/core/templates/test_crs/ProjectParametersOrchestrator.json
+++ b/kratos_element_test/core/templates/test_crs/ProjectParametersOrchestrator.json
@@ -51,7 +51,6 @@
             "compute_reactions":                  true,
             "move_mesh_flag":                     false,
             "reform_dofs_at_each_step":           false,
-            "nodal_smoothing":                    false,
             "block_builder":                      true,
             "solution_type":                      "Quasi-Static",
             "scheme_type":                        "Backward_Euler",

--- a/kratos_element_test/core/templates/test_direct_shear/ProjectParameters.json
+++ b/kratos_element_test/core/templates/test_direct_shear/ProjectParameters.json
@@ -30,7 +30,6 @@
         "compute_reactions"                  : true,
         "move_mesh_flag"                     : false,
         "reform_dofs_at_each_step"           : false,
-        "nodal_smoothing"                    : false,
         "block_builder"                      : true,
         "reset_displacements"                : true,
         "convergence_criterion"              : "residual_criterion",

--- a/kratos_element_test/core/templates/test_triaxial/ProjectParameters.json
+++ b/kratos_element_test/core/templates/test_triaxial/ProjectParameters.json
@@ -30,7 +30,6 @@
         "compute_reactions"                  : true,
         "move_mesh_flag"                     : false,
         "reform_dofs_at_each_step"           : false,
-        "nodal_smoothing"                    : false,
         "block_builder"                      : true,
         "reset_displacements"                : true,
         "convergence_criterion"              : "residual_criterion",


### PR DESCRIPTION
The `nodal_smoothing` has been removed from the KratosGeoMechanicsApplication. This PR is for the removal of the `nodal_smoothing` parameter in the project_parameters.json template files of the tests.