### PR TITLE
Fix the startElementTest script after folder refactor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ openpyxl = "*"
 KratosGeoMechanicsApplication = ">=10.2.3"
 
 [tool.poetry.scripts]
-startElementTest = "kratos_element_test.ui.kratos_element_test_gui:main"
+startElementTest = "kratos_element_test.view.kratos_element_test_gui:main"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
After the `ui` folder got renamed to `view`, the script in the toml file didn't get updated, meaning the command doesn't currently work