### PR TITLE
Fixed pip install error message in pipeline

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -38,7 +38,7 @@ jobs:
           python-version: 3.13
           cache: 'pip'
       - name: Install dependencies
-        run: pip install --upgrade pip .
+        run: python -m pip install --upgrade pip .
       - name: Run code quality checks
         run: pylint kratos_element_test --output-format=github --fail-under 5 --fail-on E
       - name: Check formatting


### PR DESCRIPTION
I'm not too sure why, but the pipelines worked before and started failing as of today with the following error:
```
ERROR: To modify pip, please run the following command:
C:\hostedtoolcache\windows\Python\3.13.11\x64\python.exe -m pip install --upgrade pip .
```

It seems that it's not good practice (and it seems here also not possible) to upgrade pip while it's running (see https://stackoverflow.com/questions/76753043/what-are-the-advantages-of-python-exe-m-pip-install-over-pip-install-comman)

This PR fixes the error by changing `pip install <options>` to `python -m pip install <options>`, so running python with the pip module instead of running pip directly